### PR TITLE
Fix `SmsEvent::EVENT_POST_SEND` , remove `zend-captcha` required

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ return [
                     [
                         'name' => SmsCode::class,
                         'options' => [
-                            'input_name' => 'phone',
+                            'inputName' => 'phone',
                             'cache' => 'SmsCache'
                         ]
                     ]

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
     "suggest": {
         "zendframework/zend-cache": "LimitSendListener,SmsCode required",
         "zendframework/zend-i18n": "PhoneNumber validation required",
-        "zendframework/zend-captcha": "SmsCode required",
         "zendframework/zend-inputfilter": "ValidationListener required"
     }
 }

--- a/src/Captcha/SmsCode.php
+++ b/src/Captcha/SmsCode.php
@@ -4,15 +4,14 @@ namespace Zfegg\SmsSender\Captcha;
 
 use Zend\Cache\Storage\Adapter\AbstractAdapter as AbstractCacheAdapter;
 use Zend\Cache\StorageFactory;
-use Zend\Captcha\AbstractAdapter;
-use Zend\Validator\Exception;
+use Zend\Validator\AbstractValidator;
 
 /**
  * Class SmsCode
  *
  * @package Zfegg\SmsSender\Captcha
  */
-class SmsCode extends AbstractAdapter
+class SmsCode extends AbstractValidator
 {
     const MISSING_PHONE_NUMBER_INPUT = 'missingPhoneNumberInput';
     const EXPIRE_CODE = 'expireCode';
@@ -201,13 +200,5 @@ class SmsCode extends AbstractAdapter
         }
 
         return $code;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getHelperName()
-    {
-        return 'formtext';
     }
 }

--- a/src/Factory/SmsCodeCaptchaFactory.php
+++ b/src/Factory/SmsCodeCaptchaFactory.php
@@ -3,12 +3,10 @@
 namespace Zfegg\SmsSender\Factory;
 
 use Interop\Container\ContainerInterface;
-use Zfegg\SmsSender\Captcha\SmsCode;
-use Zend\Cache\StorageFactory;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\ValidatorPluginManager;
+use Zfegg\SmsSender\Captcha\SmsCode;
 
 /**
  * Class SmsCodeValidatorFactory

--- a/src/Listener/LimitSendListener.php
+++ b/src/Listener/LimitSendListener.php
@@ -2,11 +2,11 @@
 
 namespace Zfegg\SmsSender\Listener;
 
-use Zend\Cache\StorageFactory;
-use Zfegg\SmsSender\SmsEvent;
 use Zend\Cache\Storage\Adapter\AbstractAdapter;
+use Zend\Cache\StorageFactory;
 use Zend\EventManager\AbstractListenerAggregate;
 use Zend\EventManager\EventManagerInterface;
+use Zfegg\SmsSender\SmsEvent;
 
 /**
  * Class LimitSendListener

--- a/src/Listener/ValidatorListener.php
+++ b/src/Listener/ValidatorListener.php
@@ -2,11 +2,11 @@
 
 namespace Zfegg\SmsSender\Listener;
 
+use Zend\EventManager\AbstractListenerAggregate;
+use Zend\EventManager\EventManagerInterface;
 use Zend\InputFilter\Factory;
 use Zend\InputFilter\InputFilter;
 use Zfegg\SmsSender\SmsEvent;
-use Zend\EventManager\AbstractListenerAggregate;
-use Zend\EventManager\EventManagerInterface;
 
 /**
  * Class ValidatorListener

--- a/src/SmsSender.php
+++ b/src/SmsSender.php
@@ -65,7 +65,8 @@ class SmsSender implements EventManagerAwareInterface
         try {
             $result = $this->getProvider()->send($phoneNumber, $content);
             $event->setParam('result', $result);
-            $events->trigger(SmsEvent::EVENT_POST_SEND, $event);
+            $event->setName(SmsEvent::EVENT_POST_SEND);
+            $events->triggerEvent($event);
             return true;
         } catch (\Exception $e) {
             $event->setParam('exception', $e);

--- a/test/SmsSenderTest.php
+++ b/test/SmsSenderTest.php
@@ -42,16 +42,21 @@ class SmsSenderTest extends \PHPUnit_Framework_TestCase
 
         $provider  = $this->getProviderMock();
         $smsSender = new SmsSender($provider);
+        $events = $smsSender->getEventManager();
 
+        //Test send success
+        $events->attach(SmsEvent::EVENT_POST_SEND, function (SmsEvent $event) use ($phoneNumber) {
+            $this->assertEquals($phoneNumber, $event->getPhoneNumber());
+        });
         $this->assertTrue($smsSender->send($phoneNumber, $content));
 
-        $events = $smsSender->getEventManager();
 
         $invalidEventName = '';
         $invalidCall      = function (SmsEvent $event) use (&$invalidEventName) {
             $this->assertEquals($invalidEventName, $event->getError());
         };
         $events->attach(SmsEvent::EVENT_INVALID, $invalidCall);
+
 
         //Assert pre send invalid
         $invalidEventName = SmsEvent::EVENT_PRE_SEND;


### PR DESCRIPTION
1. `SmsCode` change extends , and remove `Zend\Captcha\AbstractAdapter`, remove `zendframework/zend-captcha` required.
2. Fix `SmsSender::send` trigger `SmsEvent::EVENT_POST_SEND`.
3. Optimize class imports.
